### PR TITLE
Update TF version and ppc64le providers version

### DIFF
--- a/openshift-install-powervs
+++ b/openshift-install-powervs
@@ -68,8 +68,8 @@ TF='./terraform'
 CLI_PATH='./ibmcloud'
 OC_PATH='./oc'
 
-TF_LATEST="v0.13.5"
-TF_PPC64LE_PROVIDERS="v0.7"
+TF_LATEST="v0.13.6"
+TF_PPC64LE_PROVIDERS="v0.8"
 
 ARTIFACTS_DIR="automation"
 LOGFILE="ocp4-upi-powervs_$(date "+%Y%m%d%H%M%S")"

--- a/openshift-install-powervs
+++ b/openshift-install-powervs
@@ -68,6 +68,9 @@ TF='./terraform'
 CLI_PATH='./ibmcloud'
 OC_PATH='./oc'
 
+TF_LATEST="v0.13.5"
+TF_PPC64LE_PROVIDERS="v0.7"
+
 ARTIFACTS_DIR="automation"
 LOGFILE="ocp4-upi-powervs_$(date "+%Y%m%d%H%M%S")"
 TRACE=0
@@ -1087,7 +1090,6 @@ function setup_artifacts() {
 #-------------------------------------------------------------------------
 function setup_terraform {
   #TF_LATEST=$(curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d'"' -f4)
-  TF_LATEST="v0.13.5"
   EXT_PATH=$(which terraform 2> /dev/null || true)
 
   if [[ -f $TF && $($TF version | grep 'Terraform v0') == "Terraform ${TF_LATEST}" ]]; then
@@ -1114,7 +1116,6 @@ function setup_terraform {
 # Install latest terraform providers for ppc64le
 #-------------------------------------------------------------------------
 function setup_terraform_providers {
-  TF_PPC64LE_PROVIDERS="v0.7"
   retry "curl -fsSL https://github.com/ocp-power-automation/terraform-providers-power/releases/download/$TF_PPC64LE_PROVIDERS/archive.zip -o archive.zip"
   unzip -o "./archive.zip" >/dev/null 2>&1
   rm -f "./archive.zip"


### PR DESCRIPTION
1. Moving the TF version variables up for global updates in future.
2. Update the TF version to use v0.13.6 (from v0.13.5) as that is also available for Power.
3. Update the ppc64le providers artifact version to v0.8 to include latest ibm-cloud plugin update.

Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>