### PR TITLE
Update the power providers to include new ibm provider version

### DIFF
--- a/openshift-install-powervs
+++ b/openshift-install-powervs
@@ -72,7 +72,6 @@ CLI_PATH="$INSTALL_DIR/ibmcloud"
 OC_PATH="$INSTALL_DIR/oc"
 
 TF_LATEST="v0.13.6"
-TF_PPC64LE_PROVIDERS="v0.8"
 
 ARTIFACTS_DIR="automation"
 LOGFILE="ocp4-upi-powervs_$(date "+%Y%m%d%H%M%S")"
@@ -1137,7 +1136,8 @@ function setup_terraform {
 # Install latest terraform providers for ppc64le
 #-------------------------------------------------------------------------
 function setup_terraform_providers {
-  retry "curl -fsSL https://github.com/ocp-power-automation/terraform-providers-power/releases/download/$TF_PPC64LE_PROVIDERS/archive.zip -o archive.zip"
+  TF_PPC64LE_PROVIDERS=$(curl -s https://api.github.com/repos/ocp-power-automation/terraform-providers-power/releases/latest| grep browser_download_url | grep 'archive.zip' | cut -d'"' -f4)
+  retry "curl -fsSL $TF_PPC64LE_PROVIDERS -o archive.zip"
   unzip -o "./archive.zip" >/dev/null 2>&1
   rm -f "./archive.zip"
 }


### PR DESCRIPTION
Need to use latest version v0.9 wrt to ibm cloud provider update in the Terraform automation code for PowerVS.

This makes the code always use the latest providers version. No need to update the version each time from now on

Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>